### PR TITLE
from `cat` to `message`

### DIFF
--- a/R/linda.R
+++ b/R/linda.R
@@ -199,10 +199,10 @@ linda <- function(otu.tab, meta, formula, type = 'count',
         }
         corr.pval <- coef(summary(tmp))[-1, "Pr(>|t|)"]
         if(any(corr.pval <= corr.cut)) {
-          cat('Imputation approach is used.\n')
+          message('Imputation approach is used')
           imputation <- TRUE
         } else {
-          cat('Pseudo-count approach is used.\n')
+          message('Pseudo-count approach is used.')
           imputation <- FALSE
         }
       }


### PR DESCRIPTION
Cat is not a great way to output information to the user, especially in case of a rmarkdown or quarto document where the user may not want to see those. message/warning, in base R, are more suitable, in general.